### PR TITLE
Pages: Don't set template for pages using page-contentfull

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -1,9 +1,6 @@
-<script>
-{
-	"title": "About",
- 	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "About"
+}</script>
 
 <h2>Touch-Optimized Web Framework</h2>
 

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -1,6 +1,5 @@
 <script>{
 	"title": "Changelogs",
-	"pageTemplate": "page-contentfull.php",
 	"noHeadingLinks": true
 }</script>
 

--- a/pages/changelog/1.1.2.md
+++ b/pages/changelog/1.1.2.md
@@ -1,6 +1,5 @@
 <script>{
-    "title": "jQuery Mobile 1.1.2 Changelog",
-     "pageTemplate": "page-contentfull.php"
+	"title": "jQuery Mobile 1.1.2 Changelog"
 }</script>
 
 ### Button

--- a/pages/changelog/1.2.0.md
+++ b/pages/changelog/1.2.0.md
@@ -1,6 +1,5 @@
 <script>{
-    "title": "jQuery Mobile 1.2.0 Changelog",
-     "pageTemplate": "page-contentfull.php"
+	"title": "jQuery Mobile 1.2.0 Changelog"
 }</script>
 
 ### Button

--- a/pages/changelog/1.2.1.md
+++ b/pages/changelog/1.2.1.md
@@ -1,6 +1,5 @@
 <script>{
-    "title": "jQuery Mobile 1.2.1 Changelog",
-     "pageTemplate": "page-contentfull.php"
+	"title": "jQuery Mobile 1.2.1 Changelog"
 }</script>
 
 ### Blur

--- a/pages/changelog/1.3.0.md
+++ b/pages/changelog/1.3.0.md
@@ -1,6 +1,5 @@
 <script>{
-    "title": "jQuery Mobile 1.3.0 Changelog",
-     "pageTemplate": "page-contentfull.php"
+	"title": "jQuery Mobile 1.3.0 Changelog"
 }</script>
 
 ### Button

--- a/pages/changelog/1.3.1.md
+++ b/pages/changelog/1.3.1.md
@@ -1,6 +1,5 @@
 <script>{
-    "title": "jQuery Mobile 1.3.1 Changelog",
-     "pageTemplate": "page-contentfull.php"
+	"title": "jQuery Mobile 1.3.1 Changelog"
 }</script>
 
 ### Button

--- a/pages/changelog/1.3.2.md
+++ b/pages/changelog/1.3.2.md
@@ -1,6 +1,5 @@
 <script>{
-    "title": "jQuery Mobile 1.3.2 Changelog",
-     "pageTemplate": "page-contentfull.php"
+	"title": "jQuery Mobile 1.3.2 Changelog"
 }</script>
 
 ### Popup

--- a/pages/changelog/1.4.0.md
+++ b/pages/changelog/1.4.0.md
@@ -1,5 +1,5 @@
 <script>{
-"title": "jQuery Mobile 1.4.0 Changelog"
+	"title": "jQuery Mobile 1.4.0 Changelog"
 }</script>
 
 ### Accessibility

--- a/pages/demos.html
+++ b/pages/demos.html
@@ -1,9 +1,6 @@
-<script>
-{
-	"title": "Demos",
- 	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "Demos"
+}</script>
 
 <h2>Latest stable version</h2>
 

--- a/pages/donate-devices.html
+++ b/pages/donate-devices.html
@@ -1,9 +1,6 @@
-<script>
-{
-	"title": "Donate Devices",
- 	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "Donate Devices"
+}</script>
 
 <p>Our philosophy is to target <a href="/gbs/">the widest possible range of devices</a>, so that no browser or device is left behind. To pursue this, we constantly need new devices on which to test our framework to ensure that all users receive the best jQuery Mobile experience.</p>
 

--- a/pages/download-builder.html
+++ b/pages/download-builder.html
@@ -1,9 +1,6 @@
-<script>
-{
-	"title": "jQuery Mobile Download Builder",
-	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "jQuery Mobile Download Builder"
+}</script>
 <link rel="stylesheet" href="../resources/builder/builder.css" />
 <script src="../resources/builder/builder.js"></script>
 <script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.3/underscore-min.js"></script>

--- a/pages/download.html
+++ b/pages/download.html
@@ -1,9 +1,6 @@
-<script>
-{
-	"title": "Download",
-  "pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "Download"
+}</script>
 
 <h2 id="download">Download Builder</h2>
 <p>We recommend using our tool to build a custom bundle that contains only the components you need. The builder generates a custom JavaScript file, as well as full and structure-only stylesheets for production use.</p>

--- a/pages/download/all.md
+++ b/pages/download/all.md
@@ -1,6 +1,5 @@
 <script>{
 	"title": "All Downloads",
-	"pageTemplate": "page-contentfull.php",
 	"noHeadingLinks": true
 }</script>
 

--- a/pages/gbs.html
+++ b/pages/gbs.html
@@ -1,9 +1,7 @@
-<script>
-{
-	"title": "Graded Browser Support",
-	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "Graded Browser Support"
+}</script>
+
 <h2>Supported platforms</h2>
 
 <p>jQuery Mobile has broad support for the vast majority of all modern desktop, smartphone, tablet, and e-reader platforms. In addition, feature phones and older browsers are supported because of our progressive enhancement approach. We're very proud of our commitment to universal accessibility through our broad support for all popular platforms.</p>

--- a/pages/gbs/1.3.html
+++ b/pages/gbs/1.3.html
@@ -1,9 +1,7 @@
-<script>
-{
-	"title": "jQuery Mobile 1.3 Supported Platforms",
-	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "jQuery Mobile 1.3 Supported Platforms"
+}</script>
+
 <h2>Platform support in 1.3</h2>
 
 <p>We use a 3-level graded platform support system: A (full), B (full minus Ajax), C (basic HTML). The visual fidelity of the experience and smoothness of page transitions are highly dependent on the CSS rendering capabilities of the device and platform so not all A grade experience will be pixel-perfect but that’s the nature of the web.</p>

--- a/pages/gbs/1.4.html
+++ b/pages/gbs/1.4.html
@@ -1,9 +1,7 @@
-<script>
-{
-	"title": "jQuery Mobile 1.4 Supported Platforms",
-	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "jQuery Mobile 1.4 Supported Platforms"
+}</script>
+
 <h2>Platform support in 1.4</h2>
 
 <p>We use a 3-level graded platform support system: A (full), B (full minus Ajax), C (basic HTML). The visual fidelity of the experience and smoothness of page transitions are highly dependent on the CSS rendering capabilities of the device and platform so not all A grade experience will be pixel-perfect but that’s the nature of the web.</p>

--- a/pages/resources.html
+++ b/pages/resources.html
@@ -1,9 +1,7 @@
-<script>
-{
-	"title": "Resources",
-  "pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "Resources"
+}</script>
+
 <style>
 table.featuredsites { }
 table.featuredsites td { padding-top:32px; text-align:center; }

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -1,9 +1,6 @@
-<script>
-{
-	"title": "Roadmap",
-	"pageTemplate": "page-contentfull.php"
-}
-</script>
+<script>{
+	"title": "Roadmap"
+}</script>
 
 <p>The roadmap shows what we are planning to work on. Please note that this can be subject to change.</p>
 

--- a/pages/upgrade-guide.md
+++ b/pages/upgrade-guide.md
@@ -1,6 +1,5 @@
 <script>{
 	"title": "Upgrade Guides",
-	"pageTemplate": "page-contentfull.php",
 	"noHeadingLinks": true
 }</script>
 

--- a/pages/upgrade-guide/1.4.md
+++ b/pages/upgrade-guide/1.4.md
@@ -1,6 +1,5 @@
 <script>{
-    "title": "jQuery Mobile 1.4 Upgrade Guide",
-     "pageTemplate": "page-contentfull.php"
+	"title": "jQuery Mobile 1.4 Upgrade Guide"
 }</script>
 
 The 1.4 upgrade guide will be published here within a few days.


### PR DESCRIPTION
Since there is no sidebar on any page, the default page template should be
page-contentfull instead of page. The other half of this change is in
jquery-wp-content.

The change in jquery-wp-content is equivalent to this: https://github.com/jquery/jquery-wp-content/blob/master/themes/jquery.com/page.php
