### PR TITLE
New "Team" section on About page

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -14,18 +14,6 @@
 <p>And we are never done! Check out <a href="/roadmap/" title="jQuery Mobile roadmap">roadmap</a> to see what the jQuery Mobile team is planning to work on.</p>
 <hr>
 
-<h2>Team</h2>
-<ul>
-<li><a href="https://github.com/arschmitz" title="Alexander Schmitz profile">Alexander Schmitz</a> - Project Lead</li>
-<li><a href="https://github.com/agcolom" title="Anne-Gaelle Colom GitHub profile">Anne-Gaelle Colom</a> - Documentation Lead</li>
-<li><a href="https://github.com/gabrielschulhof" title="Gabriel Schulhof GitHub profile">Gabriel Schulhof</a></li>
-<li><a href="https://github.com/gseguin" title="Ghislain Seguin GitHub profile">Ghislain Seguin</a></li>
-<li><a href="https://github.com/jaspermdegroot" title="Jasper de Groot GitHub profile">Jasper de Groot</a></li>
-</ul>
-
-<p>The Mobile team is having its weekly meeting at Thursday 2 PM (EST) on <a href="http://irc.jquery.org">IRC</a> in the #jquery-meeting channel. Meeting notes are posted on http://meetings.jquery.org/category/mobile/ after each meeting.</p>
-<hr>
-
 <h2>Support</h2>
 
 <p>The jQuery Mobile community provides a friendly, helpful environment when you need development advice. The best way to get help is to post on the <a href="http://forum.jquery.com/jquery-mobile/">forum</a> or use the IRC support channel: #jquery on irc.freenode.net.</p>
@@ -38,3 +26,92 @@
 <p>The jQuery Foundation is financed entirely by donations and contributions from the jQuery community. Please support the project by <a href="https://jquery.org/donate">making a donation</a> or <a href="https://jquery.org/join/">becoming a member</a> of the jQuery Foundation.</p>
 
 <p>You can also help the project by <a href="/donate-devices/">donating devices</a> to our test lab.</p>
+<hr>
+
+<h2>Team</h2>
+
+<!-- @todo Remove this style block and add styles to https://github.com/jquery/jquery-wp-content/blob/master/themes/jquerymobile.com/style.css -->
+<style>
+    #content .team {
+        list-style: none;
+        margin: 25px 0;
+        padding: 0;
+    }
+    #content .team > li {
+        background: none;
+        border-bottom: 1px solid #dbdbdb;
+        margin-bottom: 15px;
+        padding: 0 10px;
+        text-align: center
+    }
+    #content .team > li > img {
+        margin-bottom: 15px;
+        width: 90px;
+    }
+    #content .team > li > h3 > span {
+        display: block;
+        font-size: 0.8125em;
+        margin-top: 10px;
+    }
+    #content .team > li > p {
+        text-align: left;
+    }
+    
+    @media (min-width:700px) {
+        #content .team > li {
+            padding-left: 0;
+            text-align: left;
+        }
+        #content .team > li:after {
+            clear: both;
+            content: " ";
+            display: block;
+        }
+        #content .team > li > img {
+            float: left;
+            margin: 0 20px 15px 0;
+            width: 120px;
+        }
+        #content .team > li > h3 > span {
+            display: inline-block;
+            font-size: 1em;
+            margin-top: 0;
+        }
+        #content .team > li > h3 > span:before {
+            content: "\00a0\2014\00a0";
+        }
+        #content .team > li > p {
+            max-width: 800px;
+        }
+    }
+</style>
+
+<ul class="team">
+	<li>
+		<img src="https://secure.gravatar.com/avatar/c7ebb4bf8014513304378a9a4d025faa?size=120" alt="Avatar Alexander Schmitz">
+		<h3><a href="https://github.com/arschmitz" title="Alexander Schmitz profile" target="_blank">Alexander Schmitz</a><span>Project Lead</span></h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed luctus a orci id luctus. Praesent sed ipsum nisl. Pellentesque eu orci id neque efficitur tempus. Ut feugiat ornare magna, ut consequat felis rutrum vitae.</p>
+	</li>
+	<li>
+		<img src="https://secure.gravatar.com/avatar/b2bef16d251e5dfe3be5e31182a822b6?size=120" alt="Avatar Anne-Gaelle Colom">
+		<h3><a href="https://github.com/agcolom" title="Anne-Gaelle Colom GitHub profile" target="_blank">Anne-Gaelle Colom</a><span>Documentation Lead</span></h3>
+		<p>Anne-Gaelle Colom is a Senior Lecturer at the <a href="http://www.westminster.ac.uk/" target="_blank">University of Westminster</a> in London, UK. She is passionate about the use of technology in Higher Education as well as the Web and Mobile world. Anne-Gaelle joined the jQuery Mobile team in October 2011 to become the documentation lead a few months later.</p>
+	</li>
+	<li>
+		<img src="https://secure.gravatar.com/avatar/acabeff49b5ba95a8e94de9445175f56?size=120" alt="Avatar Gabriel Schulhof">
+		<h3><a href="https://github.com/gabrielschulhof" title="Gabriel Schulhof GitHub profile" target="_blank">Gabriel Schulhof</a></h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed luctus a orci id luctus. Praesent sed ipsum nisl. Pellentesque eu orci id neque efficitur tempus. Ut feugiat ornare magna, ut consequat felis rutrum vitae.</p>
+	</li>
+	<li>
+		<img src="https://secure.gravatar.com/avatar/691460b4005b0c16bcb96dcdf1f0e02d?size=120" alt="Avatar Cory Gackenheimer">
+		<h3><a href="https://github.com/cgack" title="Cory Gackenheimer GitHub profile" target="_blank">Cory Gackenheimer</a></h3>
+		<p>Cory Gackenheimer is a software engineer at <a href="http://www.healthx.com/" target="_blank">Healthx</a> by day. After hours he works as a <a href="http://www.apress.com/9781430260585" title="Apress" target="_blank">writer</a>, speaker, and consultant. In his role with jQuery Mobile he works to triage bugs and implementing new features.</p>
+	</li>
+	<li>
+		<img src="https://secure.gravatar.com/avatar/e8170d7574cd649bce2639e24737de88?size=120" alt="Avatar Jasper de Groot">
+		<h3><a href="https://github.com/jaspermdegroot" title="Jasper de Groot GitHub profile" target="_blank">Jasper de Groot</a></h3>
+		<p>Jasper de Groot is a Dutch freelance web developer, residing in Barcelona, Spain. He is specializing in WordPress theme development. Jasper joined the team in 2012 and focuses on the CSS side of the project and the demos.</p>
+	</li>
+</ul>
+
+<p>The Mobile team is having its weekly meeting at Thursday 2 PM (EST) on <a href="http://irc.jquery.org">IRC</a> in the #jquery-meeting channel. Meeting notes are posted on <a href="http://meetings.jquery.org/category/mobile/">meetings.jquery.org</a> after each meeting.</p>


### PR DESCRIPTION
TO DO:
- [ ] Text Alex
- [x] Text Anne
- [ ] Text Gabriel
- [ ] Text Amanpreet
- [x] Text Cory
- [x] Text Jasper
- [x] Add `target="_blank"` to GitHub profile links
- [ ] Remove inline styles from pages/about.html: Open PR in jquery-wp-content repo to add styles to the jquerymobile.com stylesheet

Screenshot:
![about jquery mobile](https://cloud.githubusercontent.com/assets/1296793/6512769/a19a1552-c376-11e4-9ad1-9afcd72bc24d.png)

Small screens:
![about jquery mobile small](https://cloud.githubusercontent.com/assets/1296793/6512772/a64396c8-c376-11e4-9767-3d0dced6e272.png)
