### PR TITLE
Fix broken builder page

### DIFF
--- a/pages/download-builder.html
+++ b/pages/download-builder.html
@@ -3,7 +3,7 @@
 }</script>
 <link rel="stylesheet" href="../resources/builder/builder.css">
 <script src="../resources/builder/builder.js"></script>
-<script src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.3/underscore-min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.3.3/underscore-min.js"></script>
 
 <p>Customize your jQuery Mobile download by selecting the specific modules you need in the form below. For standard configurations, <a href="/download">download or link to CDN versions</a> of pre-built packages. Please note that the jQuery Mobile Download Builder is still in alpha, and as such should <em>not</em> be used on production websites.</p>
 <p>Please report any issues you might find in the <a href="https://github.com/jquery/jquerymobile.com/issues">issue tracker</a>, and thanks!</p>

--- a/resources/builder/builder.js
+++ b/resources/builder/builder.js
@@ -1,5 +1,5 @@
 $( function( $ ) {
-	var host = "http://amd-builder.jquerymobile.com",
+	var host = "https://amd-builder.jquerymobile.com",
 		dependencyMap,
 		builderhtml = [],
 		sortable = [],


### PR DESCRIPTION
Mixed Content: The page at 'https://jquerymobile.com/download-builder/' was loaded over HTTPS, but requested an insecure script. This request has been blocked; the content must be served over HTTPS.
Fixes #148, fixes #146, fixes #143 
